### PR TITLE
[1612] Don't make the creator of a group an admin

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -599,19 +599,22 @@ def _group_or_org_create(context, data_dict, is_org=False):
 
     # creator of group/org becomes an admin
     # this needs to be after the repo.commit or else revisions break
-    member_dict = {
-        'id': group.id,
-        'object': user_id,
-        'object_type': 'user',
-        'capacity': 'admin',
-    }
-    member_create_context = {
-        'model': model,
-        'user': user,
-        'ignore_auth': True, # we are not a member of the group at this point
-        'session': session
-    }
-    logic.get_action('member_create')(member_create_context, member_dict)
+
+    # DGU don't add the user as an admin because all groups are created by sysadmin
+    # issue #1612
+    #member_dict = {
+    #    'id': group.id,
+    #    'object': user_id,
+    #    'object_type': 'user',
+    #    'capacity': 'admin',
+    #}
+    #member_create_context = {
+    #    'model': model,
+    #    'user': user,
+    #    'ignore_auth': True, # we are not a member of the group at this point
+    #    'session': session
+    #}
+    #logic.get_action('member_create')(member_create_context, member_dict)
 
     log.debug('Created object %s' % group.name)
     return model_dictize.group_dictize(group, context)


### PR DESCRIPTION
I tried different ways of accomplishing this including using an IOrganizationController plugin, but that didn't work as the plugin is called before the membership is created.
