### PR TITLE
Fix to allow tests to run correctly

### DIFF
--- a/ckan/tests/__init__.py
+++ b/ckan/tests/__init__.py
@@ -301,7 +301,8 @@ class TestSearchIndexer:
         from ckan import plugins
         if not is_search_supported():
             raise SkipTest("Search not supported")
-        plugins.load('synchronous_search')
+        if not plugins.plugin_loaded("synchronous_search"):
+            plugins.load('synchronous_search')
 
     @classmethod
     def index(cls):


### PR DESCRIPTION
If more than one class subclassed the TestSearchIndexer class then the
tests fail because the plugin is already loaded.  Now guards against the
plugin already being loaded.