### PR TITLE
Optimisations for sqlalchemy cache

### DIFF
--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -80,8 +80,10 @@ class Member(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a group object referenced by its id or name.'''
-        query = meta.Session.query(cls).filter(cls.id == reference)
-        member = query.first()
+        if not reference:
+            return None
+
+        member = meta.Session.query(cls).get(reference)
         if member is None:
             member = cls.by_name(reference)
         return member

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -76,8 +76,10 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a package object referenced by its id or name.'''
-        query = meta.Session.query(cls).filter(cls.id==reference)
-        pkg = query.first()
+        if not reference:
+            return None
+
+        pkg = meta.Session.query(cls).get(reference)
         if pkg == None:
             pkg = cls.by_name(reference)
         return pkg

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -138,8 +138,10 @@ class Resource(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a resource object referenced by its name or id.'''
-        query = meta.Session.query(Resource).filter(Resource.id == reference)
-        resource = query.first()
+        if not reference:
+            return None
+
+        resource = meta.Session.query(cls).get(reference)
         if resource is None:
             resource = cls.by_name(reference)
         return resource

--- a/ckan/model/task_status.py
+++ b/ckan/model/task_status.py
@@ -24,7 +24,10 @@ class TaskStatus(domain_object.DomainObject):
     @classmethod
     def get(cls, reference):
         '''Returns a task status object referenced by its id.'''
-        query = meta.Session.query(cls).filter(cls.id==reference)
-        return query.first()
+        if not reference:
+            return None
+
+        task = meta.Session.query(cls).get(reference)
+        return task
 
 meta.mapper(TaskStatus, task_status_table)


### PR DESCRIPTION
Contains the ckan/ckan/commit/a359bce80067569e4f2d0ca7b7c4e00665e11460 and ckan/ckan/commit/181290d3b7911a406398a1b95dbb0794b4e42a78 that change how our models ```get``` method works so that it might pull from the sqlalchemy cache instead of going to the database all the time.