### PR TITLE
Ignore revision_id when passed via resource

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -97,6 +97,7 @@ def default_resource_schema():
 
 def default_update_resource_schema():
     schema = default_resource_schema()
+    schema['revision_id'] = [ignore]
     return schema
 
 def default_tags_schema():


### PR DESCRIPTION
From wardi/ckan/commit/ba40eec65a4ae53fe3b242e81029232f254fbae6 

Ignores the revision_id when it is passed to the schema for updates.