### PR TITLE
[WIP] Group changes to support collections

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -458,7 +458,8 @@ class GroupController(base.BaseController):
                    'for_edit': True,
                    'parent': request.params.get('parent', None)
                    }
-        data_dict = {'id': id}
+        data_dict = {'id': id, 'type': group_type}
+
 
         if context['save'] and not data:
             return self._save_edit(id, context)
@@ -476,7 +477,6 @@ class GroupController(base.BaseController):
         group = context.get("group")
         c.group = group
         c.group_dict = self._action('group_show')(context, data_dict)
-
         try:
             self._check_access('group_update', context)
         except NotAuthorized, e:
@@ -541,8 +541,7 @@ class GroupController(base.BaseController):
             context['message'] = data_dict.get('log_message', '')
             data_dict['id'] = id
             context['allow_partial_update'] = True
-            # DGU does not have packages on its group form
-            context['prevent_packages_update'] = True
+
             group = self._action('group_update')(context, data_dict)
             if id != group['name']:
                 self._force_reindex(group)

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -542,6 +542,8 @@ class GroupController(base.BaseController):
             data_dict['id'] = id
             context['allow_partial_update'] = True
 
+            context['prevent_packages_update'] = True
+
             group = self._action('group_update')(context, data_dict)
             if id != group['name']:
                 self._force_reindex(group)

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -385,14 +385,13 @@ def group_member_save(context, group_dict, member_table_name):
     return processed
 
 
-def group_dict_save(group_dict, context):
+def group_dict_save(group_dict, context, prevent_packages_update=False):
     from ckan.lib.search import rebuild
 
     model = context["model"]
     session = context["session"]
     group = context.get("group")
     allow_partial_update = context.get("allow_partial_update", False)
-    prevent_packages_update = context.get("prevent_packages_update", False)
 
     Group = model.Group
     if group:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -23,7 +23,7 @@ import ckan.lib.search as search
 import ckan.lib.plugins as lib_plugins
 import ckan.lib.activity_streams as activity_streams
 import ckan.new_authz as new_authz
-import ckan.lib.lazyjson as lazyjson 
+import ckan.lib.lazyjson as lazyjson
 from paste.deploy.converters import asbool
 
 from ckan.common import _
@@ -633,7 +633,6 @@ def organization_list_for_user(context, data_dict):
 
     orgs_list = model_dictize.group_list_dictize(orgs_q.all(), context)
     return orgs_list
-
 
 def _group_or_org_revision_list(context, data_dict):
     '''Return a group's revisions.

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -483,6 +483,8 @@ def _group_or_org_update(context, data_dict, is_org=False):
     if group is None:
         raise NotFound('Group was not found.')
 
+    context['prevent_packages_update'] = group.is_organization
+
     # get the schema
     group_plugin = lib_plugins.lookup_group_plugin(group.type)
     try:
@@ -529,13 +531,6 @@ def _group_or_org_update(context, data_dict, is_org=False):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    # when editing an org we do not want to update the packages if using the
-    # new templates.
-    if ((not is_org)
-            and not converters.asbool(
-                config.get('ckan.legacy_templates', False))
-            and 'api_version' not in context):
-        context['prevent_packages_update'] = True
     group = model_save.group_dict_save(data, context)
 
     if is_org:

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -483,8 +483,6 @@ def _group_or_org_update(context, data_dict, is_org=False):
     if group is None:
         raise NotFound('Group was not found.')
 
-    context['prevent_packages_update'] = group.is_organization
-
     # get the schema
     group_plugin = lib_plugins.lookup_group_plugin(group.type)
     try:
@@ -531,7 +529,7 @@ def _group_or_org_update(context, data_dict, is_org=False):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    group = model_save.group_dict_save(data, context)
+    group = model_save.group_dict_save(data, context,prevent_packages_update=is_org)
 
     if is_org:
         plugin_type = plugins.IOrganizationController


### PR DESCRIPTION
Some changes to allow us to use a group subtype without breakage.

Mostly just passes the group_type to the action functions where it is known, and only prevents package updates for organisations/publishers.

This will be required to close https://github.com/datagovuk/ckanext-dgu/issues/340
